### PR TITLE
#1 #2 계정유형 분개 추가, refreshToken 정책 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ fun String?.nullWhenEmpty() = if (this.isNullOrEmpty()) null else this
 
 dependencies {
     implementation("com.ssu.commerce:ssu-commerce-core:$coreVersion")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.2")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/ssu/commerce/auth/configs/AuthUrlPermission.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/configs/AuthUrlPermission.kt
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 class AuthUrlPermission : UrlPermissionFilter {
     override fun urlPermissions(authorizeRequests: ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry): ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry =
         authorizeRequests
-            .antMatchers(HttpMethod.POST, "/sign-in", "/sign-up").permitAll()
+            .antMatchers(HttpMethod.POST, "/sign-in", "/sign-up", "/refresh").permitAll()
             .anyRequest().authenticated()
 
     @Bean

--- a/src/main/kotlin/com/ssu/commerce/auth/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/controller/auth/AuthController.kt
@@ -3,6 +3,7 @@ package com.ssu.commerce.auth.controller.auth
 import com.ssu.commerce.auth.service.AuthService
 import com.ssu.commerce.core.security.AuthInfo
 import com.ssu.commerce.core.security.Authenticated
+import com.ssu.commerce.core.security.UserRole
 import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -29,7 +30,8 @@ class AuthController(
 
 data class SignInRequest(
     val id: String,
-    val password: String
+    val password: String,
+    val userRole: UserRole?
 )
 
 data class SignUpRequest(

--- a/src/main/kotlin/com/ssu/commerce/auth/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/controller/auth/AuthController.kt
@@ -22,6 +22,10 @@ class AuthController(
     fun signUp(@RequestBody signUpRequest: SignUpRequest) =
         authService.signUp(signUpRequest)
 
+    @PostMapping("/refresh")
+    fun signIn(@RequestBody refreshTokenRequest: RefreshTokenRequest) =
+        authService.refreshToken(refreshTokenRequest)
+
     @GetMapping("/info")
     fun test(@Authenticated @Parameter(hidden = true) authInfo: AuthInfo): AuthInfo {
         return authInfo
@@ -37,4 +41,9 @@ data class SignInRequest(
 data class SignUpRequest(
     val id: String,
     val password: String
+)
+
+data class RefreshTokenRequest(
+    val accessToken: String,
+    val refreshToken: String
 )

--- a/src/main/kotlin/com/ssu/commerce/auth/domain/Account.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/domain/Account.kt
@@ -38,6 +38,7 @@ data class Account(
     fun checkEmailVerifiedUser() {
         // TODO 이메일 인증 진행시 구현
     }
+
     fun createPointAccount(): PointAccount {
         checkEmailVerifiedUser()
         return PointAccount(
@@ -46,6 +47,8 @@ data class Account(
             status = PointAccountStatus.ACTIVE
         )
     }
+
+    fun getRefreshToken() = refreshToken
 
     fun updateRefreshToken(tokens: SessionTokens): SessionTokens {
         refreshToken = tokens.refreshToken.token

--- a/src/main/kotlin/com/ssu/commerce/auth/exception/AuthExceptions.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/exception/AuthExceptions.kt
@@ -6,5 +6,8 @@ import org.springframework.http.HttpStatus
 class SignInFailedException(message: String? = null) :
     SsuCommerceException(HttpStatus.BAD_REQUEST, "AUTH-1", message ?: "로그인에 실패했습니다.")
 
+class RefreshFailedException(message: String? = null) :
+    SsuCommerceException(HttpStatus.BAD_REQUEST, "AUTH-2", message ?: "다른 클라이언트에서 로그인이 감지되었습니다. 재로그인해주세요.")
+
 class EmailVerificationNotCompletedException(message: String? = null) :
-    SsuCommerceException(HttpStatus.BAD_REQUEST, "AUTH-2", message ?: "이메일 인증이 되지 않은 계정입니다.")
+    SsuCommerceException(HttpStatus.BAD_REQUEST, "AUTH-3", message ?: "이메일 인증이 되지 않은 계정입니다.")

--- a/src/main/kotlin/com/ssu/commerce/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/ssu/commerce/auth/service/AuthService.kt
@@ -27,6 +27,7 @@ class AuthService(
     fun signIn(req: SignInRequest): SessionTokens =
         accountRepository.findByUserId(req.id)
             ?.apply { password.verifyPassword(req.password) }
+            ?.apply { req.userRole?.let { if (!roles.contains(it)) throw SignInFailedException() } }
             ?.let { it.updateRefreshToken(issueTokens(it.userId, it.roles)) }
             ?: throw SignInFailedException()
 


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bufix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes
계정 유형별로 다르게 로그인 검증할 필요가 있어 추가
토큰 갱신로직이 필요하여 추가
## Reason for change

## Detailed Description


## mention

Resolves: #1 #2 
See also: #